### PR TITLE
Get log messages

### DIFF
--- a/src/sds.ts
+++ b/src/sds.ts
@@ -531,7 +531,7 @@ export class Response {
         return returnList;
     }
 
-    public getBool(name: ParameterName): boolean {
+    public getBoolean(name: ParameterName): boolean {
         responseLog.debug(`getBool(${ParameterName[name]})`);
         const paramIndex = this.getParamIndex(name);
         const headType = this.buffer[paramIndex];
@@ -815,7 +815,7 @@ export class SDSConnection {
         connectionLog.debug(`runScriptOnServer`);
         return new Promise<string>((resolve, reject) => {
             this.send(Message.runScriptOnServer(sourceCode)).then((response: Response) => {
-                const success = response.getBool(ParameterName.ReturnValue);
+                const success = response.getBoolean(ParameterName.ReturnValue);
                 if (success) {
                     const returnedString = response.getString(ParameterName.Parameter);
                     resolve(returnedString);

--- a/test/sds.test.ts
+++ b/test/sds.test.ts
@@ -161,6 +161,25 @@ suite('SDS protocol tests', () => {
             }).catch(err => done(err));
         });
 
+        test('create GetLogMessages message', done => {
+            const lastSeen = -1;
+
+            connection.send(Message.getLogMessages(lastSeen)).then(() => {
+                assert.equal(1, socket.out.length);
+                let packet = socket.out[0];
+                assert.equal(27, packet.length);
+                const bytes = [
+                    0x00, 0x00, 0x00, 0x1b, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0xd1, 0x03, 0x58, 0x00,
+                    0x00, 0x00, 0x0a, 0x03, 0x08, 0xff, 0xff, 0xff,
+                    0xff, 0x02, 0x33,
+                ];
+                assert.ok(packet.equals(Buffer.from(bytes)));
+
+                done();
+            }).catch(err => done(err));
+        });
+
         suite('establish a new connection', () => {
 
             test('server refused connection', done => {

--- a/test/sds.test.ts
+++ b/test/sds.test.ts
@@ -41,7 +41,7 @@ suite('SDS protocol tests', () => {
             ];
             const res = new Response(Buffer.from(bytes));
             assert.equal(35, res.length);
-            assert.equal(true, res.getBool(ParameterName.ReturnValue));
+            assert.equal(true, res.getBoolean(ParameterName.ReturnValue));
             assert.equal('Hello, world!', res.getString(ParameterName.Parameter));
         });
 


### PR DESCRIPTION
This PR adds a new function

```ts
    getLogMessages(lastSeen: number): Promise<LogMessages>
```

along with a new interface

```ts
    interface LogMessages {
        lastSeen: number;
        lines: string[];
    }
```

to the API. This allows retrieving of server log messages directly via SDS.

This feature is needed for this issue: [Display server console in output channel](https://github.com/otris/vscode-janus-debug/issues/26) in vscode-janus-debug. For a working console-only example see https://gitlab.otris.de/kircher/server-console (only reachable from inside company network).